### PR TITLE
Fix query instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ For example:
 #### Did I join?
 Check if an address was successfully entered in the raffle
 ```
-secretcli q compute contract query <contract-address> '{"registered": {"address": "<your address>"}}'
+secretcli q compute query <contract-address> '{"registered": {"address": "<your address>"}}'
 ```
 
 #### See who won
 See who was selected as the winner
 ```
-secretcli q compute contract query <contract-address> '{"winner": {}}'
+secretcli q compute query <contract-address> '{"winner": {}}'
 ```
 
 ### As a raffle host


### PR DESCRIPTION
The `contract` query calls the contract without arguments, so you should user `query` instead.
Wrong:
```
ubuntu@sentry:/usr/local/bin/secret-node$ secretcli q compute contract query secret1h74ummlyfp6zk0cf3394yx5vn92t37g4h6hjjm '{ "registered": { "address": "secret196sdplwg3efdtgsth5cutcppnsw29r6cjfkfvs" }}'
ERROR: accepts 1 arg(s), received 3
```
Right:
```
ubuntu@sentry:/usr/local/bin/secret-node$ secretcli q compute query secret1h74ummlyfp6zk0cf3394yx5vn92t37g4h6hjjm '{ "joined": { "address": "secret196sdplwg3efdtgsth5cutcppnsw29r6cjfkfvs" }}'
secret196sdplwg3efdtgsth5cutcppnsw29r6cjfkfvs is registered
```